### PR TITLE
Fix brew detection redirection in mac bootstrap script

### DIFF
--- a/scripts/bootstrap-mac.sh
+++ b/scripts/bootstrap-mac.sh
@@ -13,7 +13,7 @@ if ! xcode-select -p >/dev/null 2>&1; then
 fi
 
 # 1) Install Homebrew if missing
-if ! command -v brew >/div/null 2>&1; then
+if ! command -v brew >/dev/null 2>&1; then
 	echo "🍺 Installing Homebrew…"
 	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi


### PR DESCRIPTION
## Summary
- ensure Homebrew detection uses /dev/null redirection

## Testing
- `bash -n scripts/bootstrap-mac.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a0b8b1f618832daa929d82f746c601