### PR TITLE
Add Wayland/GUI packages to Arch bootstrap

### DIFF
--- a/packages/arch.txt
+++ b/packages/arch.txt
@@ -44,6 +44,12 @@ neovim
 lua-language-server
 tree-sitter-cli
 xclip
+# Wayland/GUI
+xorg-xwayland
+mesa
+hyprland
+chromium
+alacritty
 sqlite
 mariadb-clients
 ffmpeg


### PR DESCRIPTION
## Summary
- add a Wayland/GUI section to the Arch package list
- ensure xorg-xwayland, mesa, hyprland, chromium, and alacritty are installed during Arch setup

## Testing
- bash -n scripts/install_arch.sh
- bash -n scripts/bootstrap.sh

------
https://chatgpt.com/codex/tasks/task_e_68d74de6f418832d94c7a0b0f1645a82